### PR TITLE
allow data option to be a yml file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,15 @@ module.exports = function(grunt) {
           }
         ]
       },
+      yml_data_file: {
+        files: [
+          {
+            data: 'test/fixtures/objects/hello_world.yml',
+            template: 'test/fixtures/templates/hello_world.twig',
+            dest: 'tmp/hello_world_yml_data_file.html'
+          }
+        ]
+      },
       pojo_data_file: {
         files: [
           {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ grunt.initConfig({
       },
       files : [
         {
-          data: // Path to JSON file, or POJO
+          data: // Path to JSON or YAML file, or POJO
           template: // Path to template file
           dest: // Path to output destination here
         }

--- a/tasks/twig_render.js
+++ b/tasks/twig_render.js
@@ -78,9 +78,11 @@ module.exports = function(grunt) {
   GruntTwigRender.prototype._getDataFromFile = function(dataPath) {
     if (/\.json/i.test(dataPath)) {
       return grunt.file.readJSON(dataPath);
+    } else if (/\.yml/i.test(dataPath) || /\.yaml/i.test(dataPath)) {
+      return grunt.file.readYAML(dataPath);
     }
     else {
-      grunt.log.warn("Data file does not seem to be JSON. Trying to evaluate the file's contents into an javascript object. Use at your own risk!");
+      grunt.log.warn("Data file does not seem to be JSON or YAML. Trying to evaluate the file's contents into an javascript object. Use at your own risk!");
       return eval( '(' + grunt.file.read(dataPath) + ')' );
     }
   };

--- a/test/fixtures/objects/hello_world.yml
+++ b/test/fixtures/objects/hello_world.yml
@@ -1,0 +1,2 @@
+greeting: Hello
+reversed_target: dlrow

--- a/test/twig_render_test.js
+++ b/test/twig_render_test.js
@@ -36,6 +36,15 @@ exports.twig_render = {
 
     test.done();
   },
+  yml_data_file: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/hello_world_yml_data_file.html');
+    var expected = grunt.file.read('test/expected/hello_world.html');
+    test.equal(actual, expected, 'should render when given yml data.');
+
+    test.done();
+  },
   pojo_data_file: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
This allows to define a path to a YAML file as data option.
It checks for the extensions `.yml` and `.yaml`.
