### PR TITLE
enh: added option to set Twig cache, and defaulted to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,14 @@ Will result in 4 files (`myDest_0-3.html`)
 
 ### Options
 
+#### options.cache
+Type: `Boolean`  
+Default value: `false`
+
+Indicates if Twig should use a template cache or read template file every time.
+Default is set to false to enable template file watch and recompilation.
+Set it to true if you need to generate lots of files with an identical template.
+
 #### options.extensions
 Type: `Array`  
 Default value: `[]`
@@ -434,6 +442,10 @@ options:
 ```
 
 ## Release History
+
+__1.7.0__
+
+  * added `cache` option to enable/disable Twig caching (needed for livereload).
 
 __1.6.0__
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-twig-render",
   "description": "Render twig templates",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "homepage": "https://github.com/sullinger/grunt-twig-render",
   "author": {
     "name": "Stefan Ullinger",

--- a/tasks/twigRender.js
+++ b/tasks/twigRender.js
@@ -30,7 +30,8 @@ module.exports = function(grunt) {
   var Twig = require("twig"),
 
   DEFAULT_OPTIONS = {
-    extensions: []
+    extensions: [],
+    cache: false,
   };
 
   var json5 = null;
@@ -68,6 +69,7 @@ module.exports = function(grunt) {
     this.options.extensions.forEach(function(fn) {
       Twig.extend(fn);
     });
+    Twig.cache(this.options.cache);
   }
 
   GruntTwigRender.prototype.render = function(data, dataPath, template, dest, flatten) {


### PR DESCRIPTION
Hi,

I had some issues in my workflow where Grunt was watching template files and recompiling them but I did not see the results of my modifications.
It turns out Twig maintains an internal cache of templates and was using the old versions.

So I disabled its cache by default (grunt is a dev tool, so most of the time we should be using the freshest file), with an option to enable it if needed (you never know): options.cache
